### PR TITLE
Исправление ошибки при разворачивании окружения из docker

### DIFF
--- a/docker/python/dev/Dockerfile
+++ b/docker/python/dev/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:slim
 
 RUN apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests -y build-essential
+    && apt-get install --no-install-recommends --no-install-suggests -y build-essential libpq-dev
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Для psycopg2 не хватало утилиты pg_config
Решается установкой пакета libpq-dev